### PR TITLE
Fix documentation typo (start:dev to dev)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ you can use webpack alias (defined in each tsconfig.json and shared with [tsconf
 ### command
 
 * `yarn install`
-* `yarn start:dev`
+* `yarn dev`
 * `yarn build`
 * `yarn start`
 


### PR DESCRIPTION
Just a minor typo in documentation, the script has changed from `start:dev` to `dev` in e074793.